### PR TITLE
Fix compatibility issue by making dependencies versions more specific

### DIFF
--- a/nodeapp/package.json
+++ b/nodeapp/package.json
@@ -9,7 +9,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "socket.io": "^1.3.5",
-    "socket.io-redis": "^0.1.4"
+    "socket.io": "~1.3.5",
+    "socket.io-redis": "~0.1.4"
   }
 }


### PR DESCRIPTION
The latest version of socket.io-php-emitter (0.7.0) doesn't work with socket.io >= 1.4.0 (see https://github.com/rase-/socket.io-php-emitter/issues/20). So this commit changes package.json to force this project to use socket.io version 1.3.*.
